### PR TITLE
Allowed redirect_uri be defined manually 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ oauth2.password
 oauth2.provider
 oauth2.clientId
 oauth2.clientSecret
+oauth2.redirectUri (Optional: used to set redirect_uri on server.auth.strategy.location manually)
 ```
 
 To get the list of supported providers, see [Bell's documentation](https://github.com/hapijs/bell)

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = function (kibana) {
         sessionTimeout: Joi.number().default(30 * 60 * 1000),
         provider: Joi.string(),
         clientId: Joi.string(),
+        redirectUri: Joi.string(),
         clientSecret: Joi.string(),
         allowedIndices: Joi.array().items(Joi.string()).single(),
         allowedDomains: Joi.alternatives().when('provider', {
@@ -55,6 +56,7 @@ module.exports = function (kibana) {
           password: config.get('oauth2.password'),
           clientId: config.get('oauth2.clientId'),
           clientSecret: config.get('oauth2.clientSecret'),
+          location: config.get('oauth2.redirectUri'),          
           isSecure: !!config.get('server.ssl.cert')
         });
       });


### PR DESCRIPTION
If you are using kibana over proxy or forwarded (ex. nginx), you need set the base **redirect_uri** manually if it cannot be inferred properly from server settings. 

I added a new "oauth2.redirectUri" config that can be used to set location on server.auth.strategy

``` javascript
server.auth.strategy(config.get('oauth2.provider'), 'bell', {
          provider: config.get('oauth2.provider'),
          password: config.get('oauth2.password'),
          clientId: config.get('oauth2.clientId'),
          clientSecret: config.get('oauth2.clientSecret'),
          location: config.get('oauth2.redirectUri'),          
          isSecure: !!config.get('server.ssl.cert')
 });
```
